### PR TITLE
fix: page should scroll to show dropdown items

### DIFF
--- a/src/client/src/app/components/events/event-timeslot-dialog/event-timeslot-dialog.component.html
+++ b/src/client/src/app/components/events/event-timeslot-dialog/event-timeslot-dialog.component.html
@@ -45,6 +45,7 @@
         optionLabel="name"
         appendTo="body"
         [filter]="true"
+        [autofocusFilter]="false"
         [filterFields]="['name']"
         [showClear]="true"
       />

--- a/src/client/src/app/components/events/event-timeslot/event-timeslot.component.html
+++ b/src/client/src/app/components/events/event-timeslot/event-timeslot.component.html
@@ -167,6 +167,7 @@
                       [options]="preconfigPlayerOptions()"
                       optionLabel="alias"
                       [filter]="true"
+                      [autofocusFilter]="false"
                       filterBy="alias"
                       [resetFilterOnHide]="true"
                       (onChange)="


### PR DESCRIPTION
I did not manage to automatically scroll. But when disabling auto focus of the filter text field, when tapping on the filter field it gets correctly scrolled.

Closes: #102